### PR TITLE
Add --indels_only functionality to vcfprep

### DIFF
--- a/readcomb/vcfprep.py
+++ b/readcomb/vcfprep.py
@@ -30,7 +30,7 @@ def arg_parser():
 
     args = parser.parse_args()
 
-    return args.vcf, args.snps_only, args,indels_only, \
+    return args.vcf, args.snps_only, args.indels_only, \
             args.no_hets, args.min_GQ, args.out
 
 def vcfprep(vcf, snps_only, indels_only, no_hets, min_GQ, outfile):


### PR DESCRIPTION
Now available as a new arg. Script will raise an exception if both `snps_only` and `indels_only` are selected. 